### PR TITLE
Add support for PHP ^8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ cache:
 
 php:
     - 7.1
+    - 8.0
+    - 8.1
 
 env:
     - NETTE_CACHE="^2.3"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.1 || ^8.0",
     "nette/caching": "^2.3 || ^3.0@dev",
     "psr/cache": "^1.0"
   },


### PR DESCRIPTION
Should work without any additional changes :)

```shell
~/src/github/NetteCachingPsr6 master* 5s
❯ php vendor/bin/tester tests -p phpdbg --coverage ./coverage.xml --coverage-src ./src
 _____ ___  ___ _____ ___  ___
|_   _/ __)( __/_   _/ __)| _ )
  |_| \___ /___) |_| \___ |_|_\  v2.4.3

Note: No php.ini is used.
Code coverage by PHPDBG: /Users/petr.bugyik/src/github/NetteCachingPsr6/coverage.xml
PHP 8.1.9 (cli); PHPDBG 8.1.9 | phpdbg -qrrb -S cli -n | 8 threads

.............


OK (13 tests, 0.3 seconds)
Generating code coverage report... 94% covered
```